### PR TITLE
Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
-# datepicker enhancer
+# Datepick Enhancer
 
-![image](https://user-images.githubusercontent.com/23192045/208814065-23c13f81-0796-4ff4-be74-0ef1522b89e9.png)
+![An enhanced date picker](https://user-images.githubusercontent.com/23192045/208814065-23c13f81-0796-4ff4-be74-0ef1522b89e9.png)
 
-- the color degree based on how many  blocks created in the daily note of the day
-- the round border means that  the day was been linked.
-- the number in the corner indicates how much "due" to that day
-  - What counts as "due"?
-    - A block has [[date of day]] and is preceded by the attribute "due::" or has the tag "#due " (You can change it in settings panel)
-    - Under a `{{[[TODO]]}}` block
-    - eg:
-      - <img width="622" alt="image" src="https://user-images.githubusercontent.com/23192045/209608158-f3166598-685d-4dd7-9a58-16cabd067db5.png">
+Datepick Enhancer allows Roam's date picker to convey additional information about each date:
 
-
-
+1. **Number of blocks:** Each date is shaded according to how many blocks are present in its corresponding Daily Note. The more blocks present, the deeper the shade of green.
+1. **Mentions:** Draws an orange border when the date has been mentioned at least once.
+1. **Tasks due (optional):** An adjacent number indicating the number of tasks due for the date. A block is treated as a due task when it both:
+    1. is a `{{[[TODO]]}}`
+    1. has a child block which both:
+        1. has the attribute `due::` or the tag `#due`. (Set another page to be used in place of `due` in Datepick Enhancer's settings.)
+        1. mentions a [[date]]
+    - for example: ![Structure of a minimal due task](https://user-images.githubusercontent.com/23192045/209608158-f3166598-685d-4dd7-9a58-16cabd067db5.png)

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Each date is shaded according to how many blocks are present in its correspondin
 
 ## Mentions
 
-Draws an orange border when the date has been mentioned at least once.
+An orange border is drawn around any date which has been mentioned at least once.
 
 ## Tasks due (optional)
 
-An adjacent number indicating the number of tasks due for the date. A block is treated as a due task when it both:
+A small number next to each date indicates the number of tasks due. A block is considered a due task when it both:
 
 1. is a `{{[[TODO]]}}`
 1. has a child block which both:

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Datepick Enhancer allows Roam's date picker to convey additional information about each date:
 
-1. the number of blocks present
-1. whether the date has been mentioned
-1. the number of tasks due
+1. the [number of blocks](#number-of-blocks) present
+1. whether the date has been [mentioned](#mentions)
+1. the number of [tasks due](#tasks-due-optional)
 
 ![An enhanced date picker](https://user-images.githubusercontent.com/23192045/208814065-23c13f81-0796-4ff4-be74-0ef1522b89e9.png)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Datepick Enhancer allows Roam's date picker to convey additional information about each date:
 
-1. the [number of blocks](#number-of-blocks) present
+1. the number of [blocks present](#number-of-blocks)
 1. whether the date has been [mentioned](#mentions)
 1. the number of [tasks due](#tasks-due-optional)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Datepick Enhancer allows Roam's date picker to convey additional information about each date:
 
+1. the number of blocks present
+1. whether the date has been mentioned
+1. the number of tasks due
+
 ![An enhanced date picker](https://user-images.githubusercontent.com/23192045/208814065-23c13f81-0796-4ff4-be74-0ef1522b89e9.png)
 
 ## Number of blocks

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Datepick Enhancer allows Roam's date picker to convey additional information abo
 1. whether the date has been [mentioned](#mentions)
 1. the number of [tasks due](#tasks-due-optional)
 
-![An enhanced date picker](https://user-images.githubusercontent.com/23192045/208814065-23c13f81-0796-4ff4-be74-0ef1522b89e9.png)
+<br>
+<img alt="An enhanced date picker" src="https://user-images.githubusercontent.com/23192045/208814065-23c13f81-0796-4ff4-be74-0ef1522b89e9.png" width="300">
 
 ## Number of blocks
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ Draws an orange border when the date has been mentioned at least once.
 
 An adjacent number indicating the number of tasks due for the date. A block is treated as a due task when it both:
 
-  1. is a `{{[[TODO]]}}`
-  1. has a child block which both:
-    1. has the attribute `due::` or the tag `#due`. (Set another page to be used in place of `due` in Datepick Enhancer's settings, or `0` to disable this functionality.)
-    1. mentions a [[date]]
+1. is a `{{[[TODO]]}}`
+1. has a child block which both:
+    1. begins with `due::` or has the tag `#due`
+    1. mentions a `[[Date]]`, e.g. `[[January 1st, 2024]]`
+  
+Set another page to be used in place of `due` in Datepick Enhancer's settings, or set to `0` to disable this functionality.
 
 ### Example of a due task
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,26 @@
 # Datepick Enhancer
 
-![An enhanced date picker](https://user-images.githubusercontent.com/23192045/208814065-23c13f81-0796-4ff4-be74-0ef1522b89e9.png)
-
 Datepick Enhancer allows Roam's date picker to convey additional information about each date:
 
-1. **Number of blocks:** Each date is shaded according to how many blocks are present in its corresponding Daily Note. The more blocks present, the deeper the shade of green.
-1. **Mentions:** Draws an orange border when the date has been mentioned at least once.
-1. **Tasks due (optional):** An adjacent number indicating the number of tasks due for the date. A block is treated as a due task when it both:
-    1. is a `{{[[TODO]]}}`
-    1. has a child block which both:
-        1. has the attribute `due::` or the tag `#due`. (Set another page to be used in place of `due` in Datepick Enhancer's settings.)
-        1. mentions a [[date]]
-    - for example: ![Structure of a minimal due task](https://user-images.githubusercontent.com/23192045/209608158-f3166598-685d-4dd7-9a58-16cabd067db5.png)
+![An enhanced date picker](https://user-images.githubusercontent.com/23192045/208814065-23c13f81-0796-4ff4-be74-0ef1522b89e9.png)
+
+## Number of blocks
+
+Each date is shaded according to how many blocks are present in its corresponding Daily Note. The more blocks present, the deeper the shade of green.
+
+## Mentions
+
+Draws an orange border when the date has been mentioned at least once.
+
+## Tasks due (optional)
+
+An adjacent number indicating the number of tasks due for the date. A block is treated as a due task when it both:
+
+  1. is a `{{[[TODO]]}}`
+  1. has a child block which both:
+    1. has the attribute `due::` or the tag `#due`. (Set another page to be used in place of `due` in Datepick Enhancer's settings, or `0` to disable this functionality.)
+    1. mentions a [[date]]
+
+### Example of a due task
+
+![Structure of a minimal due task](https://user-images.githubusercontent.com/23192045/209608158-f3166598-685d-4dd7-9a58-16cabd067db5.png)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -132,10 +132,6 @@ const onDateSelect = (el: HTMLElement) => {
       if (linkedMap[uid]) {
         el.firstElementChild.classList.add("outline");
       }
-      let style = linkedMap[uid]
-        ? `
-         `
-        : "";
 
       if (blockCountMap[uid] > 0) {
         el.firstElementChild.classList.add("calendar-day");
@@ -144,8 +140,6 @@ const onDateSelect = (el: HTMLElement) => {
           `${Math.min(4, Math.ceil(blockCountMap[uid] / 20))}`
         );
       }
-
-      el.firstElementChild.setAttribute("style", style);
     });
     console.timeEnd("123");
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -166,8 +166,8 @@ const panelSetup = () => {
     settings: [
       {
         id: "due",
-        name: "Custom keyword",
-        description: 'specify a page title to replace the "due"',
+        name: "Page title for due tasks",
+        description: 'A page which will represent a due task when mentioned beneath a TODO, or 0 to disable this functionality.',
         action: {
           type: "input",
           placeholder: "due",


### PR DESCRIPTION
This PR:

1. updates the following for clarity:
    - label for settings item
    - readme
        - I might have misunderstood how the `due` functionality works, in which case the new description will be wrong or incomplete; please let me know!
1. describes how to disable the `due` functionality.  I decided to disable this because I'm not currently using it, and [its query](https://github.com/dive2Pro/roam-datepicker-enhance/blob/master/src/index.tsx#L127) is responsible for over 90% of the time that had been spent in initialisation
1. removes a few lines of code around `style` which appear to have no effect (please check)

P.S. I'm not sure whether the anchor links such as `#number-of-blocks` will work within Roam.  I can remove them if they won't.